### PR TITLE
gitignore: add idlemaster.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+idlemaster.log


### PR DESCRIPTION
If you happen to be running idlemaster from inside the build tree, the
log file will show up as an untracked file.  Creaeting a gitignore with
just the idlemaster.log file in it makes it possible to run idle_master
from the source tree.

It may even be worth adding settings.txt to the .gitignore as well, but then
making changes to the sample settings.txt requires more effort on the part of
the committer and is pretty obvious no one else should be committing changes
to it anyway.

Signed-off-by: Joe MacDonald joe_macdonald@mentor.com
