### PR TITLE
removed warning on line 158 caused by BeautifulSoup

### DIFF
--- a/Releases/Linux/start.py
+++ b/Releases/Linux/start.py
@@ -155,7 +155,7 @@ except:
 
 try:
 	badgesLeft = []
-	badgePageData = bs4.BeautifulSoup(r.text)
+	badgePageData = bs4.BeautifulSoup(r.text, "html.parser")
 	badgeSet = badgePageData.find_all("div",{"class": "badge_title_stats"})
 except:
 	logging.warning(Fore.RED + "Error finding drop info" + Fore.RESET)


### PR DESCRIPTION
Passed html parser option to BeautifulSoup to remove the warning when starting the script, the warning might confuse other users thinking it's not working.